### PR TITLE
remove blurb about Kadira

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mongo Explainer is a simple Meteor package that runs in development mode to watc
 
 ## Why build Mongo Explainer?
 
-Kadira is going away and I needed a quick way to find out which queries are slow and which ones aren't.
+I needed a quick way to find out which queries are slow and which ones aren't.
 
 ## Installing Mongo Explainer
 


### PR DESCRIPTION
Kadira is not going away. Feb 21: Hi there,

Few months ago, we were promised to release a self-hosted version of Kadira at the end of this month (Feb 2017). 

But we were trying (and still working on it) to migrate the maintenance of Kadira to some other party. With that, you could use Kadira as is and there won't be any migration process. 

That's why we didn't release the self-hosted version yet.

We haven't finalized those discussion yet. So, we won't terminate Kadira services by end of this month. We'll be running it for at-least another two months.

Thanks.
Arunoda from Kadira.